### PR TITLE
Level up to v1.2.3

### DIFF
--- a/commands/about.js
+++ b/commands/about.js
@@ -4,7 +4,7 @@ const {embedColor} = require('../config.json');
 
 const {version, homepage, license, author} = require('../package.json');
 
-const {millisToMinutesAndSeconds} = require('../util.js');
+const {millisToReadable} = require('../util.js');
 
 module.exports = {
   name: 'about',
@@ -25,7 +25,7 @@ module.exports = {
         { name: 'Author', value: `[${author}](https://github.com/muad-dweeb/ 'Hi :)')`},
         { name: 'Version', value: version, inline: true },
         { name: 'License', value: license, inline: true },
-        { name: 'Uptime', value: millisToMinutesAndSeconds(args.uptime), inline: false },
+        { name: 'Uptime (`h:m:s`)', value: millisToReadable(args.uptime), inline: false },
         { name: 'Active Guilds', value: args.guild_count, inline: false },
       )
 

--- a/ops/logrotate.conf
+++ b/ops/logrotate.conf
@@ -1,6 +1,7 @@
 /var/log/ico.log
 {
     rotate 7
+    size 1M
     daily
     missingok
     notifempty

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ico",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "ico discord bot",
   "main": "index.js",
   "dependencies": {

--- a/util.js
+++ b/util.js
@@ -30,9 +30,10 @@ module.exports = {
     return response;
   },
 
-  millisToMinutesAndSeconds: (millis) => {
+  millisToReadable: (millis) => {
+    var hours = (millis / (1000 * 60 * 60)).toFixed(0);
     var minutes = Math.floor(millis / 60000);
     var seconds = ((millis % 60000) / 1000).toFixed(0);
-    return minutes + ":" + (seconds < 10 ? '0' : '') + seconds;
+    return hours + ":" + minutes + ":" + (seconds < 10 ? '0' : '') + seconds;
   }
 };


### PR DESCRIPTION
Minor tweaks. 
- Adds hours to `about` timestamp
- Adds `h:m:s` string for clarity in `about`
- Adds size param to logrotate config